### PR TITLE
Use smooth image transformation instead of regular one

### DIFF
--- a/ImageResizer/ImageResizer.py
+++ b/ImageResizer/ImageResizer.py
@@ -133,7 +133,7 @@ def resize(im):
             return im
         # scale the image to the given height and keep ratio
         logger.debug('scale according to height: {}'.format(Setup.config['height']))
-        im = im.scaledToHeight(int(Setup.config['height']))
+        im = im.scaledToHeight(int(Setup.config['height']), Qt.SmoothTransformation)
     elif Setup.config['ratioKeep'] == 'width':
 
         if im.width() == Setup.config['width']:
@@ -141,7 +141,7 @@ def resize(im):
             return im
         # scale the image to the given width and keep ratio
         logger.debug('scale according to width: {}'.format(Setup.config['width']))
-        im = im.scaledToWidth(int(Setup.config['width']))
+        im = im.scaledToWidth(int(Setup.config['width']), Qt.SmoothTransformation)
     logger.debug('image after resizing, width: {}, height: {}'.format(im.width(), im.height()))
     return im
 


### PR DESCRIPTION
When the option to paste images as PNG isn't set, resizing jpg images can result in some ugly pixelation artefacts. This can be fixed by switching to Qt's smooth transformation mode which applies bilinear filtering. While this mode is supposed to be slower I didn't notice any speed difference at all in practice.
